### PR TITLE
Fix: Increment version to resolve failing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Once configured, Mopidy will automatically sync its volume with the specified Ho
 
 ### Changelog
 
+## v0.1.3
+- Incremented version to fix failing pipeline.
+
 ## v0.1.2
 - Initial release of the Mopidy Home Assistant Mixer.
 - Support for real-time volume sync between Mopidy and Home Assistant media players.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='mopidy-homeassistant-mixer',
-    version='0.1.2',
+    version='0.1.3',
     description='Mopidy mixer for Home Assistant media player control',
     long_description=long_description,
     long_description_content_type='text/markdown', 


### PR DESCRIPTION
I incremented the package version from 0.1.2 to 0.1.3 in setup.py. This change is intended to resolve the PyPI publishing pipeline failures caused by attempting to publish an existing version.

I updated README.md with a changelog entry for version 0.1.3.